### PR TITLE
Add Dockerfile template for Node.JS

### DIFF
--- a/plumber/templates/Dockerfile.nodejs.tpl
+++ b/plumber/templates/Dockerfile.nodejs.tpl
@@ -1,0 +1,12 @@
+FROM ubuntu:14.04
+RUN apt-get update && apt-get install -y nodejs nodejs-legacy npm git && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /srv/application
+ADD . /srv/application
+
+WORKDIR /srv/application
+RUN rm -rf node_modules && npm install
+
+ENV APP_BIND 0.0.0.0:8080
+ENTRYPOINT ["/usr/bin/npm", "start"]
+


### PR DESCRIPTION
This is a first version which builds an image from a clean Ubuntu 14.04.
It expects the Node.JS service to bind to the IP/port passed to it via
the APP_BIND environment variable and that the service defines the `npm
start` script explicitly in its package.json.
